### PR TITLE
Update the base url of Gluon ModelZoo

### DIFF
--- a/src/MxNet/Gluon/ModelZoo/ModelStore.cs
+++ b/src/MxNet/Gluon/ModelZoo/ModelStore.cs
@@ -61,7 +61,7 @@ namespace MxNet.Gluon.ModelZoo
         };
 
         private static readonly string apache_repo_url = "https://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/";
-        private static readonly string _url_format = "{0}gluon/{1}.zip";
+        private static readonly string _url_format = "{0}gluon/models/{1}.zip";
 
         public static string ShortHash(string name)
         {


### PR DESCRIPTION
The locations of Model Zoo models seem to be changed.

(old) https://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/gluon/resnet152_v2-f2695542.zip
->
(new) https://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/gluon/models/resnet152_v2-f2695542.zip