### PR TITLE
Fix crash on symbolic model execution

### DIFF
--- a/src/MxNet/Gluon/Block/HybridBlock.cs
+++ b/src/MxNet/Gluon/Block/HybridBlock.cs
@@ -44,7 +44,7 @@ namespace MxNet.Gluon
         internal (SymbolList, Symbol)? _cached_graph;
         internal CachedOp _cached_op;
         internal readonly List<CachedOpArg> _cached_op_args = new List<CachedOpArg>();
-        internal readonly NDArrayDict _flags = new NDArrayDict();
+        internal readonly Dictionary<string, string> _flags = new Dictionary<string, string>();
         internal List<int> _in_format;
         internal List<int> _out_format;
 
@@ -157,10 +157,10 @@ namespace MxNet.Gluon
                 }
             }
 
-            var flags = new NDArrayDict
+            var flags = new Dictionary<string, string>()
             {
-                {"data_indices", new NDArray(data_indices.ToArray())},
-                {"param_indices", new NDArray(param_indices.ToArray())}
+                { "data_indices", "[" + string.Join(",", data_indices.Select(i => i.ToString()).ToArray()) + "]" },
+                { "param_indices", "[" + string.Join(",", param_indices.Select(i => i.ToString()).ToArray()) + "]" }
             };
             foreach (var item in _flags) flags.Add(item.Key, item.Value);
 
@@ -185,6 +185,7 @@ namespace MxNet.Gluon
                 BuildCache(args);
 
             var (args_sym, fmt) = Flatten(args.NDArrayOrSymbols, "input");
+            _out_format = fmt.ToList();
             args = args_sym.ToList().ToNDArrays();
             var cargs = new List<NDArrayOrSymbol>();
             try

--- a/src/MxNet/Interop/MXNet/CApi.cs
+++ b/src/MxNet/Interop/MXNet/CApi.cs
@@ -319,7 +319,9 @@ namespace MxNet.Interop
         public static extern int MXCreateCachedOpEx(AtomicSymbolCreator handle, int num_flags,
             [In] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)]
             string[] keys,
-            NDArrayHandle[] vals, out AtomicSymbolCreator @out, bool thread_safe = false);
+            [In] [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)]
+            string[] vals,
+            out AtomicSymbolCreator @out, bool thread_safe = false);
 
         [DllImport(NativeLibrary, CallingConvention = CallingConvention)]
         public static extern int MXFreeCachedOp(AtomicSymbolCreator handle);

--- a/src/MxNet/NDArray/CachedOp.cs
+++ b/src/MxNet/NDArray/CachedOp.cs
@@ -20,6 +20,7 @@ using CachedOpHandle = System.IntPtr;
 using mx_uint = System.UInt32;
 using mx_float = System.Single;
 using size_t = System.UInt64;
+using System.Collections.Generic;
 
 namespace MxNet
 {
@@ -27,11 +28,11 @@ namespace MxNet
     {
         private readonly CachedOpHandle handle;
 
-        public CachedOp(Symbol sym, NDArrayDict flags)
+        public CachedOp(Symbol sym, IDictionary<string, string> flags)
         {
             handle = IntPtr.Zero;
-            NativeMethods.MXCreateCachedOpEx(sym.GetHandle(), flags.Count, flags.Keys.ToArray(),
-                MxUtil.GetNDArrayHandles(flags.Values.ToArray()), out handle);
+            Logging.CHECK_EQ(NativeMethods.MXCreateCachedOpEx(sym.GetHandle(), flags.Count, flags.Keys.ToArray(),
+                flags.Values.ToArray(), out handle, false), NativeMethods.OK);
         }
 
         public void Dispose()


### PR DESCRIPTION
The following code snippet will raise an AccessViolationException, or just crash. This pull-request will fix this.

```CSharp
        public void TestSymbolicModel()
        {
            var ctx = Context.Cpu();
            var net = new HybridSequential();
            net.Add(new Dense(1));
            net.Initialize(new Xavier(), new[] { ctx });

            // Indicate to switch to a symbolic model by calling Hybridize()
            net.Hybridize();
 
            var input = nd.Zeros(new Shape(1, 4), ctx);
            net.Call(input); // will crash
        }
````

The primary cause of the problem looks like that the declaration of `NativeMethods.MXCreateCachedOpEx()` is incorrect.
The fourth parameter `vals` should be `string[]` instead of `NDArrayHandle[]` and the argument should be given as an array of strings of python array literals like "[1, 2, 3]" (a bit surprising).