### PR TITLE
Use ListInputs() instead of ListArguments() in HybridBlock.BuildCache()

### DIFF
--- a/src/MxNet/Gluon/Block/HybridBlock.cs
+++ b/src/MxNet/Gluon/Block/HybridBlock.cs
@@ -99,7 +99,7 @@ namespace MxNet.Gluon
             var (data, @out) = GetGraph(args);
             var data_names = data.Select(x => x.Name).ToArray();
             var @params = CollectParams();
-            var input_names = @out.ListArguments().ToArray();
+            var input_names = @out.ListInputs().ToArray();
 
             var param_names = MxUtil.Set(@params.Keys().ToList()).ToArray();
             var expected_names = MxUtil.Set(input_names.ToList());

--- a/src/MxNet/Interop/MXNet/NNVMCApi.cs
+++ b/src/MxNet/Interop/MXNet/NNVMCApi.cs
@@ -13,9 +13,11 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ******************************************************************************/
+using System;
 using System.Runtime.InteropServices;
 using OpHandle = System.IntPtr;
 using nn_uint = System.UInt32;
+using SymbolHandle = System.IntPtr;
 
 // ReSharper disable once CheckNamespace
 namespace MxNet.Interop
@@ -53,6 +55,23 @@ namespace MxNet.Interop
         /// <returns>0 when success, -1 when failure happens</returns>
         [DllImport(NativeLibrary, CallingConvention = CallingConvention)]
         public static extern int NNListAllOpNames(out uint out_size, out OpHandle out_array);
+
+        /// <summary>
+        ///     List input names in the symbol.
+        /// </summary>
+        /// <param name="symbol">the symbol</param>
+        /// <param name="option">The option to list the inputs
+        ///     option=0 means list all arguments.
+        ///     option=1 means list arguments that are readed only by the graph.
+        ///     option=2 means list arguments that are mutated by the graph.</param>
+        /// <param name="out_size">output size</param>
+        /// <param name="out_str_array">pointer to hold the output string array</param>
+        /// <returns>return 0 when success, -1 when failure happens</returns>
+        [DllImport(NativeLibrary, CallingConvention = CallingConvention)]
+        public static extern int NNSymbolListInputNames(SymbolHandle symbol,
+            int type,
+            out uint out_size,
+            out IntPtr out_str_array);
 
         #endregion
     }

--- a/src/MxNet/Sym/Symbol.cs
+++ b/src/MxNet/Sym/Symbol.cs
@@ -715,6 +715,19 @@ namespace MxNet
             return ret;
         }
 
+        public IList<string> ListInputs()
+        {
+            ThrowIfDisposed();
+
+            NativeMethods.NNSymbolListInputNames(GetHandle(), 0, out var size, out var sarry);
+            var sarryArray = InteropHelper.ToPointerArray(sarry, size);
+            var ret = new string[size];
+            for (var i = 0; i < size; i++)
+                ret[i] = Marshal.PtrToStringAnsi(sarryArray[i]);
+
+            return ret;
+        }
+
         public IList<string> ListOutputs()
         {
             ThrowIfDisposed();


### PR DESCRIPTION
This pull-request modifies the implementation of `HybridBlock.BuildCache()` in accordance with the python implementation.

MxNet.Sharp's `HybridBlock.BuildCache()` uses `Symbol.ListArguments()` to obtain input names, while the python implementation uses `list_inputs()` instead of `list_arguments()`. By this PR, `Symbol.ListInputs()` is implemented and used.

I have never found any actual problems until now, but I hope this fix can avoid future troubles.

The python implementation of `_build_cache()` is here: https://github.com/apache/incubator-mxnet/blob/1.2.1/python/mxnet/gluon/block.py#L571
The definition of `Symbol.list_inputs()` is here: https://github.com/apache/incubator-mxnet/blob/1.2.1/python/mxnet/symbol/symbol.py#L811
The method signature of `NNSymbolListInputNames()` is here: https://github.com/apache/incubator-tvm/blob/7bad56b74e057a13c5577d512adf61bc82e2af86/nnvm/include/nnvm/c_api.h#L230