### PR TITLE
Symbol.GetInternals() and GetChildren() implemented

### DIFF
--- a/src/MxNet/Interop/MXNet/CApi.cs
+++ b/src/MxNet/Interop/MXNet/CApi.cs
@@ -453,6 +453,24 @@ namespace MxNet.Interop
         public static extern int MXSymbolGetName(SymbolHandle symbol, out AtomicSymbolCreator @out, out int success);
 
         /// <summary>
+        /// Get a symbol that contains all the internals.
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="out">The output symbol whose outputs are all the internals.</param>
+        /// <returns>0 when success, -1 when failure happens</returns>
+        [DllImport(NativeLibrary, CallingConvention = CallingConvention)]
+        public static extern int MXSymbolGetInternals(SymbolHandle symbol, out SymbolHandle @out);
+
+        /// <summary>
+        ///     Get a symbol that contains only direct children.
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="out">The output symbol whose outputs are the direct children.</param>
+        /// <returns>0 when success, -1 when failure happens</returns>
+        [DllImport(NativeLibrary, CallingConvention = CallingConvention)]
+        public static extern int MXSymbolGetChildren(SymbolHandle symbol, out SymbolHandle @out);
+
+        /// <summary>
         ///     Get index-th outputs of the symbol.
         /// </summary>
         /// <param name="symbol">The symbol</param>

--- a/src/MxNet/Sym/Symbol.cs
+++ b/src/MxNet/Sym/Symbol.cs
@@ -210,6 +210,21 @@ namespace MxNet
             return NativePtr;
         }
 
+        public Symbol GetInternals()
+        {
+            Logging.CHECK_EQ(NativeMethods.MXSymbolGetInternals(GetHandle(), out var handle), NativeMethods.OK);
+            return new Symbol(handle);
+        }
+
+        public Symbol GetChildren()
+        {
+            Logging.CHECK_EQ(NativeMethods.MXSymbolGetChildren(GetHandle(), out var handle), NativeMethods.OK);
+            var ret = new Symbol(handle);
+            if (ret.ListOutputs().Count == 0)
+                return null;
+            return ret;
+        }
+
         public static Symbol Group(SymbolList symbols)
         {
             var handleList = symbols.Select(symbol => symbol.GetHandle()).ToArray();


### PR DESCRIPTION
`Symbol.GetInternals()` and `Symbol.GetChildren()` implemented.

These methods are used for transfer learning.

Python implementation is here: https://github.com/apache/incubator-mxnet/blob/1.2.1/python/mxnet/symbol/symbol.py#L646