### PR TITLE
Fix an issue that HookHandle.Attach() always fails

### DIFF
--- a/src/MxNet/Gluon/HookHandle.cs
+++ b/src/MxNet/Gluon/HookHandle.cs
@@ -45,7 +45,7 @@ namespace MxNet.Gluon
 
         public void Attach(Dictionary<int, Hook> hooks_dict, Hook hook)
         {
-            if (_hooks_dict_ref == null)
+            if (_hooks_dict_ref != null)
                 throw new Exception("The same handle cannot be attached twice.");
 
             _id = hook.GetHashCode();


### PR DESCRIPTION
Fix an issue that HookHandle.Attach() always fails.