### PR TITLE
Fix initialization failure of Gluon pooling layers

### DIFF
--- a/src/MxNet/Gluon/NN/ConvLayers/_Pooling.cs
+++ b/src/MxNet/Gluon/NN/ConvLayers/_Pooling.cs
@@ -24,7 +24,9 @@ namespace MxNet.Gluon.NN
             Kernel = pool_size;
             Strides = strides ?? pool_size;
             Padding = padding;
+            CeilMode = ceil_mode;
             GlobalPool = global_pool;
+            PoolType = pool_type;
             Layout = layout;
             CountIncludePad = count_include_pad;
         }


### PR DESCRIPTION
Fix an issue that the constructor of _Pooling forget part of parameters.