### PR TITLE
Add error checking to Operator.Invoke() and CachedOp.Call()

### DIFF
--- a/src/MxNet/NDArray/CachedOp.cs
+++ b/src/MxNet/NDArray/CachedOp.cs
@@ -43,8 +43,8 @@ namespace MxNet
 
         public NDArrayList Call(NDArrayList args)
         {
-            NativeMethods.MXInvokeCachedOpEx(handle, args.Length, MxUtil.GetNDArrayHandles(args), out var num_outputs,
-                out var outputs, out var out_stypes);
+            Logging.CHECK_EQ(NativeMethods.MXInvokeCachedOpEx(handle, args.Length, MxUtil.GetNDArrayHandles(args), out var num_outputs,
+                out var outputs, out var out_stypes), NativeMethods.OK);
             var result = new NDArrayList();
             for (var i = 0; i < num_outputs; i++)
                 result.Add(new NDArray(outputs[i]).ToSType((StorageStype) out_stypes[i]));

--- a/src/MxNet/Sym/Operator.cs
+++ b/src/MxNet/Sym/Operator.cs
@@ -179,9 +179,9 @@ namespace MxNet
 
                 NDArrayHandle[] outputsReceivers = { outputsReceiver };
 
-                NativeMethods.MXImperativeInvoke(_Handle, numInputs, _InputNdarrays.ToArray(), ref numOutputs,
+                Logging.CHECK_EQ(NativeMethods.MXImperativeInvoke(_Handle, numInputs, _InputNdarrays.ToArray(), ref numOutputs,
                     ref outputsReceiver,
-                    paramKeys.Count, paramKeys.ToArray(), paramValues.ToArray());
+                    paramKeys.Count, paramKeys.ToArray(), paramValues.ToArray()), NativeMethods.OK);
 
                 if (outputs.Length > 0)
                 {


### PR DESCRIPTION
Add error checking to Operator.Invoke() and CachedOp.Call().

Error checking is necessary because these methods can raise errors by improper calls by users. (for example, addition of two NDArrays with different shapes)