### PR TITLE
Fix examples\ImageClassification\AlexGluon.cs for better results

### DIFF
--- a/examples/ImageClassification/AlexnetGluon.cs
+++ b/examples/ImageClassification/AlexnetGluon.cs
@@ -14,7 +14,8 @@ namespace ImageClassification
         {
             var alex_net = AlexNet.GetAlexNet(true);
             var image = Img.ImRead("goldfish.jpg");
-            image = Img.ResizeShort(image, 227);
+            image = Img.ResizeShort(image, 224);
+            image = Img.CenterCrop(image, (224, 224)).Item1;
             image = image.AsType(DType.Float32) / 255;
             var normalized = Img.ColorNormalize(image, new NDArray(new[] { 0.485f, 0.456f, 0.406f }),
                 new NDArray(new[] { 0.229f, 0.224f, 0.225f }));


### PR DESCRIPTION
This PR will fix preprocessing code of AlexGluon.cs according to the [mxnet tutorial page](https://mxnet.incubator.apache.org/versions/1.6/api/python/docs/tutorials/packages/gluon/image/pretrained_models.html).

- The image size that AlexNet accepts is 224 x 224, not 227.
- ResizeShort() will resize a shorter edge to a specified size so that the length of the longer edge can exceed 224. Thus, we need to add CenterCrop() after ResizeShort() to fit an image to the expected size.

The current code works, but I hope this PR will produce better results.