### PR TITLE
Make Logging.ThrowException a writable property and set its default value to true

### DIFF
--- a/src/MxNet/Logging/Logging.cs
+++ b/src/MxNet/Logging/Logging.cs
@@ -62,7 +62,7 @@ namespace MxNet
 
         private static readonly string[] OperatorSymbols;
 
-        private static readonly bool ThrowException = false;
+        public static bool ThrowException { get; set; } = true;
 
         #endregion
 


### PR DESCRIPTION
In the current implementation, errors that are raised from native methods show error messages and continue code execution.
In my experience, most of such errors are critical and ignoring them often results in more serious errors like AccessViolationException, which means that the native code has crashed somewhere. This doesn't seem to be safe for average users.

This PR will make Logging.ThrowException a writable property and set its default value to true. By this change, errors from native methods will cause exceptions by default, and knowledgeable users can change its behavior by setting the property value to false.