### PR TITLE
ToString() methods of the Gluon.NN layers implemented

### DIFF
--- a/src/MxNet/Gluon/Block/Block.cs
+++ b/src/MxNet/Gluon/Block/Block.cs
@@ -368,5 +368,11 @@ namespace MxNet.Gluon
 
             return (arg_types, aux_types);
         }
+
+        public override string ToString()
+        {
+            var modstr = string.Join("\n", _childrens.Select(i => $"  ({i.Key}): {Utils.Indent(i.Value.ToString(), 2)}"));
+            return $"{GetType().Name}(\n{modstr}\n)";
+        }
     }
 }

--- a/src/MxNet/Gluon/NN/Activations/Activation.cs
+++ b/src/MxNet/Gluon/NN/Activations/Activation.cs
@@ -42,7 +42,7 @@ namespace MxNet.Gluon.NN
 
         public override string ToString()
         {
-            return Prefix + Alias();
+            return $"{GetType().Name}({ActType})";
         }
     }
 }

--- a/src/MxNet/Gluon/NN/Activations/ELU.cs
+++ b/src/MxNet/Gluon/NN/Activations/ELU.cs
@@ -36,5 +36,10 @@ namespace MxNet.Gluon.NN
 
             return sym.LeakyReLU(x.SymX, act_type: ReluActType.Elu, slope: Alpha, symbol_name: "fwd");
         }
+
+        public override string ToString()
+        {
+            return $"{GetType().Name}({Alpha})";
+        }
     }
 }

--- a/src/MxNet/Gluon/NN/Activations/GELU.cs
+++ b/src/MxNet/Gluon/NN/Activations/GELU.cs
@@ -28,5 +28,10 @@ namespace MxNet.Gluon.NN
 
             return sym.LeakyReLU(x.SymX, act_type: ReluActType.Gelu, symbol_name: "fwd");
         }
+
+        public override string ToString()
+        {
+            return GetType().Name;
+        }
     }
 }

--- a/src/MxNet/Gluon/NN/Activations/LeakyReLU.cs
+++ b/src/MxNet/Gluon/NN/Activations/LeakyReLU.cs
@@ -36,5 +36,10 @@ namespace MxNet.Gluon.NN
 
             return sym.LeakyReLU(x.SymX, slope: Alpha);
         }
+
+        public override string ToString()
+        {
+            return $"{GetType().Name}({Alpha})";
+        }
     }
 }

--- a/src/MxNet/Gluon/NN/Activations/PReLU.cs
+++ b/src/MxNet/Gluon/NN/Activations/PReLU.cs
@@ -36,5 +36,10 @@ namespace MxNet.Gluon.NN
 
             return sym.LeakyReLU(x.SymX, alpha, ReluActType.Prelu, symbol_name: "fwd");
         }
+
+        public override string ToString()
+        {
+            return GetType().Name;
+        }
     }
 }

--- a/src/MxNet/Gluon/NN/Activations/SELU.cs
+++ b/src/MxNet/Gluon/NN/Activations/SELU.cs
@@ -28,5 +28,10 @@ namespace MxNet.Gluon.NN
 
             return sym.LeakyReLU(x.SymX, act_type: ReluActType.Selu, symbol_name: "fwd");
         }
+
+        public override string ToString()
+        {
+            return GetType().Name;
+        }
     }
 }

--- a/src/MxNet/Gluon/NN/Activations/Swish.cs
+++ b/src/MxNet/Gluon/NN/Activations/Swish.cs
@@ -31,5 +31,10 @@ namespace MxNet.Gluon.NN
 
             return sym.Sigmoid(x.SymX * Beta, "fwd");
         }
+
+        public override string ToString()
+        {
+            return $"{GetType().Name}({Beta})";
+        }
     }
 }

--- a/src/MxNet/Gluon/NN/BaseLayers/BatchNorm.cs
+++ b/src/MxNet/Gluon/NN/BaseLayers/BatchNorm.cs
@@ -66,5 +66,11 @@ namespace MxNet.Gluon.NN
 
             return sym.BatchNorm(x.SymX, gamma.SymX, beta.SymX, running_mean.SymX, running_var.SymX, eps: Epsilon, momentum: Momentum, axis: Axis, use_global_stats: Use_Global_Stats, fix_gamma: FixGamma, symbol_name: "fwd");
         }
+
+        public override string ToString()
+        {
+            var in_channels = Params["gamma"].Shape[0];
+            return $"{GetType().Name}(axis={Axis}, eps={Epsilon}, momentum={Momentum}, fix_gamma={!Scale}, use_global_stats={Use_Global_Stats}, in_channels={(in_channels > 0 ? in_channels.ToString() : "None")})";
+        }
     }
 }

--- a/src/MxNet/Gluon/NN/BaseLayers/Dense.cs
+++ b/src/MxNet/Gluon/NN/BaseLayers/Dense.cs
@@ -20,16 +20,17 @@ namespace MxNet.Gluon.NN
     public class Dense : HybridBlock
     {
         public Dense(int units, ActivationType? activation = null, bool use_bias = true, bool flatten = true,
-            DType dtype = null, Initializer weight_initializer = null, string bias_initializer = "zeros",
+            DType dtype = null, string weight_initializer = null, string bias_initializer = "zeros",
             int in_units = 0, string prefix = null, ParameterDict @params = null) : base(prefix, @params)
         {
             Units = units;
+            InUnits = in_units;
             Act = activation != null ? new Activation(activation.Value) : null;
             UseBias = use_bias;
             Flatten_ = flatten;
             DataType = dtype;
             this["weight"] = Params.Get("weight", OpGradReq.Write, new Shape(units, in_units), dtype,
-                init: weight_initializer, allow_deferred_init: true);
+                init: Initializer.Get(weight_initializer), allow_deferred_init: true);
 
             if (UseBias)
                 this["bias"] = Params.Get("bias", OpGradReq.Write, new Shape(units), dtype,
@@ -63,6 +64,12 @@ namespace MxNet.Gluon.NN
                 output = Act.HybridForward(output);
 
             return output;
+        }
+
+        public override string ToString()
+        {
+            var shape = Params["weight"].Shape;
+            return $"{GetType().Name} ({(shape.Dimension >= 2 && shape[1] > 0 ? shape[1].ToString() : "None")} -> {shape[0]}, {(Act == null ? "linear" : Act.ToString())})";
         }
     }
 }

--- a/src/MxNet/Gluon/NN/BaseLayers/Dropout.cs
+++ b/src/MxNet/Gluon/NN/BaseLayers/Dropout.cs
@@ -41,5 +41,10 @@ namespace MxNet.Gluon.NN
 
             return x;
         }
+
+        public override string ToString()
+        {
+            return $"{GetType().Name}(p={Rate}, axes={(Axes != null ? Axes.ToString() : "()")})";
+        }
     }
 }

--- a/src/MxNet/Gluon/NN/BaseLayers/Embedding.cs
+++ b/src/MxNet/Gluon/NN/BaseLayers/Embedding.cs
@@ -27,7 +27,7 @@ namespace MxNet.Gluon.NN
             Output_Dim = output_dim;
             Dtype = dtype;
             Sparse_Grad = sparse_grad;
-            Weight = Params.Get("weight", OpGradReq.Write, new Shape(input_dim, output_dim), dtype,
+            this["weight"] = Params.Get("weight", OpGradReq.Write, new Shape(input_dim, output_dim), dtype,
                 init: Initializer.Get(weight_initializer), allow_deferred_init: true,
                 grad_stype: Sparse_Grad ? StorageStype.RowSparse : StorageStype.Default);
         }
@@ -47,5 +47,11 @@ namespace MxNet.Gluon.NN
 
             return sym.Embedding(x.SymX, weight.SymX, Input_Dim, Output_Dim, Dtype, Sparse_Grad);
         }
+
+        public override string ToString()
+        {
+            return $"{GetType().Name}({Input_Dim} -> {Output_Dim}, {Dtype ?? DType.Float32})";
+        }
+
     }
 }

--- a/src/MxNet/Gluon/NN/BaseLayers/Flatten.cs
+++ b/src/MxNet/Gluon/NN/BaseLayers/Flatten.cs
@@ -28,5 +28,10 @@ namespace MxNet.Gluon.NN
 
             return sym.Flatten(x.SymX, "fwd");
         }
+
+        public override string ToString()
+        {
+            return GetType().Name;
+        }
     }
 }

--- a/src/MxNet/Gluon/NN/BaseLayers/HybridLambda.cs
+++ b/src/MxNet/Gluon/NN/BaseLayers/HybridLambda.cs
@@ -31,5 +31,10 @@ namespace MxNet.Gluon.NN
         {
             return Function(x, args);
         }
+
+        public override string ToString()
+        {
+            return $"{GetType().Name}(<lambda>)";
+        }
     }
 }

--- a/src/MxNet/Gluon/NN/BaseLayers/HybridSequential.cs
+++ b/src/MxNet/Gluon/NN/BaseLayers/HybridSequential.cs
@@ -14,6 +14,7 @@
    limitations under the License.
 ******************************************************************************/
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MxNet.Gluon.NN
 {
@@ -57,6 +58,12 @@ namespace MxNet.Gluon.NN
             foreach (var item in _childrens) x = item.Value.Call(x, args);
 
             return x;
+        }
+
+        public override string ToString()
+        {
+            var modstr = string.Join("\n", _childrens.Select(c => $"  ({c.Key}): {Utils.Indent(c.Value.ToString(), 2)}"));
+            return $"{GetType().Name}(\n{modstr}\n)";
         }
     }
 }

--- a/src/MxNet/Gluon/NN/BaseLayers/InstanceNorm.cs
+++ b/src/MxNet/Gluon/NN/BaseLayers/InstanceNorm.cs
@@ -28,9 +28,9 @@ namespace MxNet.Gluon.NN
             Center = center;
             Scale = scale;
             In_Channels = in_channels;
-            Gamma = Params.Get("gamma", scale ? OpGradReq.Write : OpGradReq.Null, new Shape(in_channels),
+            this["gamma"] = Params.Get("gamma", scale ? OpGradReq.Write : OpGradReq.Null, new Shape(in_channels),
                 init: Initializer.Get(gamma_initializer), allow_deferred_init: true);
-            Beta = Params.Get("beta", center ? OpGradReq.Write : OpGradReq.Null, new Shape(in_channels),
+            this["beta"] = Params.Get("beta", center ? OpGradReq.Write : OpGradReq.Null, new Shape(in_channels),
                 init: Initializer.Get(beta_initializer), allow_deferred_init: true);
         }
 
@@ -47,10 +47,29 @@ namespace MxNet.Gluon.NN
             var gamma = args[0];
             var beta = args[1];
 
-            if (x.IsNDArray)
-                return nd.InstanceNorm(x.NdX, gamma.NdX, beta.NdX, Epsilon);
+            if (Axis == 1)
+            {
+                if (x.IsNDArray)
+                    return nd.InstanceNorm(x.NdX, gamma.NdX, beta.NdX, Epsilon);
+                return sym.InstanceNorm(x.SymX, gamma.SymX, beta.SymX, Epsilon, "fwd");
+            }
 
-            return sym.InstanceNorm(x.SymX, gamma.SymX, beta.SymX, Epsilon, "fwd");
+            if (x.IsNDArray)
+            {
+                var xs = nd.SwapAxis(x.NdX, 1, (uint)Axis);
+                return nd.SwapAxis(nd.InstanceNorm(xs, gamma.NdX, beta.NdX, Epsilon), 1, (uint)Axis);
+            }
+            else
+            {
+                var xs = sym.SwapAxis(x.SymX, 1, Axis);
+                return sym.SwapAxis(sym.InstanceNorm(xs, gamma.SymX, beta.SymX, Epsilon, "fwd"), 1, Axis);
+            }
+        }
+
+        public override string ToString()
+        {
+            var in_channels = Params["gamma"].Shape[0];
+            return $"{GetType().Name}(eps={Epsilon}, axis={Axis}, cneter={Center}, scale={Scale}, in_channels={in_channels})";
         }
     }
 }

--- a/src/MxNet/Gluon/NN/BaseLayers/Lambda.cs
+++ b/src/MxNet/Gluon/NN/BaseLayers/Lambda.cs
@@ -30,5 +30,10 @@ namespace MxNet.Gluon.NN
         {
             return Function(input);
         }
+
+        public override string ToString()
+        {
+            return $"{GetType().Name}(<lambda>)";
+        }
     }
 }

--- a/src/MxNet/Gluon/NN/BaseLayers/LayerNorm.cs
+++ b/src/MxNet/Gluon/NN/BaseLayers/LayerNorm.cs
@@ -28,9 +28,9 @@ namespace MxNet.Gluon.NN
             Center = center;
             Scale = scale;
             In_Channels = in_channels;
-            Gamma = Params.Get("gamma", scale ? OpGradReq.Write : OpGradReq.Null, new Shape(in_channels),
+            this["gamma"] = Params.Get("gamma", scale ? OpGradReq.Write : OpGradReq.Null, new Shape(in_channels),
                 init: Initializer.Get(gamma_initializer), allow_deferred_init: true);
-            Beta = Params.Get("beta", center ? OpGradReq.Write : OpGradReq.Null, new Shape(in_channels),
+            this["beta"] = Params.Get("beta", center ? OpGradReq.Write : OpGradReq.Null, new Shape(in_channels),
                 init: Initializer.Get(beta_initializer), allow_deferred_init: true);
         }
 
@@ -51,6 +51,12 @@ namespace MxNet.Gluon.NN
                 return nd.InstanceNorm(x.NdX, gamma.NdX, beta.NdX, Epsilon);
 
             return sym.InstanceNorm(x.SymX, gamma.SymX, beta.SymX, Epsilon, "fwd");
+        }
+
+        public override string ToString()
+        {
+            var in_channels = Params["gamma"].Shape[0];
+            return $"{GetType().Name}(eps={Epsilon}, axis={Axis}, center={Center}, scale={Scale}, in_channels={in_channels})";
         }
     }
 }

--- a/src/MxNet/Gluon/NN/BaseLayers/Sequential.cs
+++ b/src/MxNet/Gluon/NN/BaseLayers/Sequential.cs
@@ -55,7 +55,8 @@ namespace MxNet.Gluon.NN
 
         public override string ToString()
         {
-            return string.Format("{0}: {1}", GetType().Name, Name);
+            var modstr = string.Join("\n", _childrens.Select(c => $"  ({c.Key}): {Utils.Indent(c.Value.ToString(), 2)}"));
+            return $"{GetType().Name}(\n{modstr}\n)";
         }
 
         public override void Hybridize(bool active = true, bool static_alloc = false, bool static_shape = false)

--- a/src/MxNet/Gluon/NN/ConvLayers/_Conv.cs
+++ b/src/MxNet/Gluon/NN/ConvLayers/_Conv.cs
@@ -117,5 +117,25 @@ namespace MxNet.Gluon.NN
         {
             return "conv";
         }
+
+        public override string ToString()
+        {
+            var shape = Params["weight"].Shape;
+            var mapping = $"{(shape.Dimension >= 2 && shape[1] > 0 ? shape[1].ToString() : "None")} -> {shape[0]}";
+            var s = $"{this.GetType().Name}({mapping}, kernel_size=({string.Join(", ", KernalSize)}), stride=({string.Join(", ", Strides)})";
+            var len_kernal_size = KernalSize.Length;
+            if (!Padding.All(i => i == 0))
+                s += $", padding=({string.Join(", ", Padding)})";
+            if (!Dialation.All(i => i == 1))
+                s += $", dilation=({string.Join(", ", Dialation)})";
+            if (NumGroup != 1)
+                s += $", groups={NumGroup}";
+            if (!UseBias)
+                s += ", bias=False";
+            if (Activation != null)
+                s += $", {Activation.Name}";
+            s += ")";
+            return s;
+        }
     }
 }

--- a/src/MxNet/Gluon/NN/ConvLayers/_Pooling.cs
+++ b/src/MxNet/Gluon/NN/ConvLayers/_Pooling.cs
@@ -64,5 +64,12 @@ namespace MxNet.Gluon.NN
         {
             return "pool";
         }
+
+        public override string ToString()
+        {
+            return $"{GetType().Name}(size=({string.Join(", ", Kernel)}), stride=({string.Join(", ", Strides)})" +
+                $", padding=({string.Join(", ", Padding)}), ceil_mode={CeilMode}" +
+                $", global_pool={GlobalPool}, pool_type={PoolType}, layout={Layout})";
+        }
     }
 }

--- a/src/MxNet/Gluon/Utils.cs
+++ b/src/MxNet/Gluon/Utils.cs
@@ -114,26 +114,21 @@ namespace MxNet.Gluon
             return total_norm;
         }
 
-        private static string Indent(string s_, int numSpaces)
+        public static string Indent(string s_, int numSpaces)
         {
             var s = s_.Split('\n');
             if (s.Length == 1)
                 return s_;
 
-            var first = s[0];
-            s.ToList().RemoveAt(0);
-            var result = first;
-            foreach (var item in s)
+            var result = new StringBuilder(s[0]);
+            foreach (var item in s.Skip(1))
             {
-                result += "\n";
-
-                for (var i = 0; i < numSpaces; i++)
-                    result += " ";
-
-                result += item;
+                result.Append('\n');
+                result.Append(' ', numSpaces);
+                result.Append(item);
             }
 
-            return result;
+            return result.ToString();
         }
 
         public static bool CheckSha1(string filename, string sha1_hash)


### PR DESCRIPTION
This pull-request will implement the `ToString()` methods of the following
`Gluon.NN` layers:

- Block, Activation, BatchNorm, Dense, Dropout, Embedding, Flatten, HybridLambda,
HybridSequential, InstanceNorm, Lambda, LayerNorm, Sequential
- All conv layers
- All pooling layers

The output formats are designed to imitate those of the python implementation as
far as I can (See the example below).

These `ToString()` methods use `Utils.Indent()`. It has a bug, which will be fixed
(`s.ToList().RemoveAt(0)` has no effect.) and it will be modified to use
`StringBuilder` because output strings can be very long for large models.

In addition, some trivial mistakes of the above classes will be fixed.
(For example, `InstanceNorm` forgets to consider the case that `AXis` is
not equal to 1.)

-----------
Example output:
```
HybridSequential(
  (0): Activation(Sigmoid)
  (1): BatchNorm(axis=1, eps=1E-05, momentum=0.9, fix_gamma=False, use_global_stats=False, in_channels=None)
  (2): Dense (None -> 64, Activation(Relu))
  (3): Dropout(p=0.1, axes=())
  (4): Embedding(3 -> 5, float32)
  (5): Flatten
  (6): HybridLambda(<lambda>)
  (7): HybridSequential(
    (0): Dense (None -> 1, linear)
    (1): Dense (None -> 2, linear)
  )
  (8): InstanceNorm(eps=1E-05, axis=2, cneter=True, scale=False, in_channels=0)
  (9): LayerNorm(eps=1E-05, axis=1, center=True, scale=False, in_channels=0)
  (10): Conv3D(None -> 3, kernel_size=(1, 2, 3), stride=(1, 1, 1))
  (11): AvgPool3D(size=(2, 2, 2), stride=(2, 2, 2), padding=(0, 0, 0), ceil_mode=False, global_pool=False, pool_type=Avg, layout=NCDHW)
)
```

Output in python for the same model:
```
HybridSequential(
  (0): Activation(Sigmoid)
  (1): BatchNorm(axis=1, eps=1e-05, momentum=0.9, fix_gamma=False, use_global_stats=False, in_channels=None)
  (2): Dense(None -> 64, Activation(Relu))
  (3): Dropout(p = 0.1, axes=())
  (4): Embedding(3 -> 5, float32)
  (5): Flatten
  (6): HybridLambda(<lambda>)
  (7): HybridSequential(
    (0): Dense(None -> 1, linear)
    (1): Dense(None -> 2, linear)
  )
  (8): InstanceNorm(eps=1e-05, axis=2, center=True, scale=False, in_channels=0)
  (9): LayerNorm(eps=1e-05, axis=-1, center=True, scale=True, in_channels=0)
  (10): Conv3D(None -> 3, kernel_size=(1, 2, 3), stride=(1, 1, 1))
  (11): AvgPool3D(size=(2, 2, 2), stride=(2, 2, 2), padding=(0, 0, 0), ceil_mode=False, global_pool=False, pool_type=avg, layout=NCDHW)
)
```