### PR TITLE
Pass NDArray as input for Cvimdecode

### DIFF
--- a/src/MxNet/NDArray/Ops.cs
+++ b/src/MxNet/NDArray/Ops.cs
@@ -138,7 +138,7 @@ namespace MxNet
         public static NDArray Cvimdecode(byte[] buf, int flag = 1, bool to_rgb = true)
         {
             return new Operator("_cvimdecode")
-                .SetParam("buf", buf)
+                .SetInput("buf", new NDArray(buf))
                 .SetParam("flag", flag)
                 .SetParam("to_rgb", to_rgb)
                 .Invoke();


### PR DESCRIPTION
Fixes issue with `Img.ImDecode()` and `nd.Cvimdecode()` by passing the input image byte array as an `NDArray`.