### PR TITLE
Fix array slicing support for NDArray

### DIFF
--- a/src/MxNet/NDArray/NDArray.cs
+++ b/src/MxNet/NDArray/NDArray.cs
@@ -750,25 +750,22 @@ namespace MxNet
                 if (string.IsNullOrEmpty(slice))
                     return this;
 
-                var (rowBegin, rowEnd, colBegin, colEnd) = MxUtil.GetSliceNotation(slice, Shape);
+                var (begin, end) = MxUtil.GetSliceNotation(slice, Shape);
 
-                if (colBegin == 0 && colEnd == 0)
-                    return Slice(rowBegin, rowEnd);
-
-                return Slice(new Shape(rowBegin, colBegin), new Shape(rowEnd, colEnd));
+                return Slice(begin, end);
             }
             set
             {
                 if (string.IsNullOrEmpty(slice))
                     value.CopyTo(this);
 
-                var (rowBegin, rowEnd, colBegin, colEnd) = MxUtil.GetSliceNotation(slice, Shape);
+                var (begin, end) = MxUtil.GetSliceNotation(slice, Shape);
                 NDArray output = null;
 
-                if(value.Size == 1)
-                    output = nd.SliceAssignScalar(this, new Shape(rowBegin, colBegin), new Shape(rowEnd, colEnd), value.AsScalar<double>());
+                if (value.Size == 1)
+                    output = nd.SliceAssignScalar(this, begin, end, value.AsScalar<double>());
                 else
-                    output = nd.SliceAssign(this, value, new Shape(rowBegin, colBegin), new Shape(rowEnd, colEnd));
+                    output = nd.SliceAssign(this, value, begin, end);
 
                 output.CopyTo(this);
             }

--- a/src/MxNet/Util/MxUtil.cs
+++ b/src/MxNet/Util/MxUtil.cs
@@ -51,56 +51,32 @@ namespace MxNet
             return keys.Distinct().OrderBy(x => x).ToList();
         }
 
-        public static (int, int, int, int) GetSliceNotation(string slice, Shape shape)
+        public static (Shape, Shape) GetSliceNotation(string slice, Shape shape)
         {
-            int rowBegin = 0, rowEnd = shape[0], colBegin = 0, colEnd = 0;
-
-            if (slice.Contains(","))
+            string[] split = slice.Split(',');
+            int[] begin = new int[split.Length];
+            int[] end = new int[split.Length];
+            for (int i = 0; i < split.Length; i++)
             {
-                var splitRowCol = slice.Split(',');
-                var rowSpan = splitRowCol[0];
-                var colSpan = splitRowCol[1];
-                var rowRange = rowSpan.Contains(":") ? rowSpan.Split(':') : null;
-                if (rowRange != null)
+                begin[i] = 0;
+                end[i] = shape[i];
+                var range = split[i].Contains(":") ? split[i].Split(':') : null;
+                if (range != null)
                 {
-                    rowBegin = !string.IsNullOrEmpty(rowRange[0]) ? Convert.ToInt32(rowRange[0].Trim()) : rowBegin;
-                    rowEnd = !string.IsNullOrEmpty(rowRange[1]) ? Convert.ToInt32(rowRange[1].Trim()) : rowEnd;
+                    begin[i] = !string.IsNullOrEmpty(range[0]) ? Convert.ToInt32(range[0].Trim()) : begin[i];
+                    end[i] = !string.IsNullOrEmpty(range[1]) ? Convert.ToInt32(range[1].Trim()) : end[i];
                 }
                 else
                 {
-                    if (!string.IsNullOrWhiteSpace(rowSpan))
+                    if (!string.IsNullOrWhiteSpace(split[i]))
                     {
-                        rowEnd = Convert.ToInt32(rowSpan.Trim());
-                        rowBegin = rowEnd - 1;
-                    }
-                }
-
-                var colRange = colSpan.Contains(":") ? colSpan.Split(':') : null;
-                if (colRange != null)
-                {
-                    colBegin = !string.IsNullOrEmpty(colRange[0]) ? Convert.ToInt32(colRange[0].Trim()) : colBegin;
-                    colEnd = !string.IsNullOrEmpty(colRange[1]) ? Convert.ToInt32(colRange[1].Trim()) : shape[1];
-                }
-                else
-                {
-                    if (!string.IsNullOrWhiteSpace(colSpan))
-                    {
-                        colEnd = Convert.ToInt32(colSpan.Trim());
-                        colBegin = colEnd - 1;
+                        begin[i] = Convert.ToInt32(split[i].Trim());
+                        end[i] = begin[i] + 1;
                     }
                 }
             }
-            else
-            {
-                var rowRange = slice.Contains(":") ? slice.Split(':') : null;
-                if (rowRange != null)
-                {
-                    rowBegin = !string.IsNullOrEmpty(rowRange[0]) ? Convert.ToInt32(rowRange[0].Trim()) : rowBegin;
-                    rowEnd = !string.IsNullOrEmpty(rowRange[1]) ? Convert.ToInt32(rowRange[1].Trim()) : rowEnd;
-                }
-            }
 
-            return (rowBegin, rowEnd, colBegin, colEnd);
+            return (new Shape(begin), new Shape(end));
         }
     }
 }


### PR DESCRIPTION
Fixes issue #5 with slicing `NDArray` with more than two dimensions.

`MxUtil.GetSliceNotation()` has been updated to return the beginning and end `Shape` that are expected by the `NDArray.Slice()`, `nd.SliceAssign()` and `nd.SliceAssignScalar()` functions.

This also fixes an issue with slicing indexes not being 0-based. For example,
`x["0"]` (say, shape is (2)) would return an `NDArray` with shape (0).
`x["1"]` would actually return the first element in the `NDArray`

Now, `x["0"]` will return the first element in the `NDArray`.

`nd.SliceAssign()` will work as long as the `DType` of both arrays are the same and the shape of the slice and input `NDArray` are the same. I wonder if it should either attempt to convert the input `NDArray` to the same `DType` as the `NDArray` being assigned, or just leave as-is.
   