### PR TITLE
Implement MxNet.Gluon.Contrib.NN.Identity

### DIFF
--- a/src/MxNet/Gluon/Contrib/NN/Identity.cs
+++ b/src/MxNet/Gluon/Contrib/NN/Identity.cs
@@ -21,12 +21,11 @@ namespace MxNet.Gluon.Contrib.NN
     {
         public Identity(string prefix = "", ParameterDict @params = null) : base(prefix, @params)
         {
-            throw new NotImplementedException();
         }
 
         public override NDArrayOrSymbol HybridForward(NDArrayOrSymbol x, params NDArrayOrSymbol[] args)
         {
-            throw new NotImplementedException();
+            return x;
         }
     }
 }


### PR DESCRIPTION
This commit will implement `MxNet.Gluon.Contrib.NN.Identity`.

`Identity` is a block that just returns an input itself.

It is used in DenseNet so that we should implement it.