### PR TITLE
Set default values for data_names and label_names of Module's constructor

### DIFF
--- a/src/MxNet/Modules/Module.cs
+++ b/src/MxNet/Modules/Module.cs
@@ -73,8 +73,8 @@ namespace MxNet.Modules
 
             _group2ctxs = group2ctxs;
             _symbol = symbol;
-            _data_names = data_names != null ? data_names : new string[0];
-            _label_names = label_names != null ? label_names : new string[0];
+            _data_names = data_names != null ? data_names : new[] { "data" };
+            _label_names = label_names != null ? label_names : new[] { "softmax_label" };
             _state_names = state_names != null ? state_names : new string[0];
             _fixed_param_names = fixed_param_names != null ? fixed_param_names : new string[0];
             CheckInputNames(symbol, _data_names, "data", true);


### PR DESCRIPTION
This PR will set default values for the `data_names` and `label_names` parameters of the constructor of the `Module` class as `'data'` and `'softmax_label'`, respectively.

This change is to follow the python implementation and is useful for actual use cases.

The python implementation is here:
https://github.com/apache/incubator-mxnet/blob/1.5.1/python/mxnet/module/module.py#L72